### PR TITLE
Add the ability to choose testing player slot as application config

### DIFF
--- a/src/AzerothWarsCSharp.Launcher/AzerothWarsCSharp.Launcher.csproj
+++ b/src/AzerothWarsCSharp.Launcher/AzerothWarsCSharp.Launcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLua" Version="1.6.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
@@ -22,6 +25,12 @@
   <ItemGroup>
     <ProjectReference Include="..\AzerothWarsCSharp.ObjectFactory\AzerothWarsCSharp.ObjectFactory.csproj" />
     <ProjectReference Include="..\War3Api.Object\War3Api.Object.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/AzerothWarsCSharp.Launcher/LaunchSettings.cs
+++ b/src/AzerothWarsCSharp.Launcher/LaunchSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace AzerothWarsCSharp.Launcher
+{
+  public sealed class LaunchSettings
+  {
+    /// <summary>
+    /// The player slot to launch the testing player as.
+    /// </summary>
+    public int TestingPlayerSlot { get; set; }
+    
+    /// <summary>
+    /// The path to your Warcraft 3 executable.
+    /// </summary>
+    public string Warcraft3ExecutablePath { get; set; }
+  }
+}

--- a/src/AzerothWarsCSharp.Launcher/Program.cs
+++ b/src/AzerothWarsCSharp.Launcher/Program.cs
@@ -18,29 +18,23 @@ namespace AzerothWarsCSharp.Launcher
   internal static class Program
   {
     // Input
-    private const string SOURCE_CODE_PROJECT_FOLDER_PATH = @"..\..\..\..\AzerothWarsCSharp.Source";
-    private const string TEST_SOURCE_CODE_PROJECT_FOLDER_PATH = @"..\..\..\..\AzerothWarsCSharp.TestSource";
-    private const string ASSETS_FOLDER_PATH = @"..\..\..\..\Assets\";
-
-    private const string BASE_MAP_PATH = @"..\..\..\..\..\maps\source.w3x";
-    private const string TEST_MAP_PATH = @"..\..\..\..\..\maps\testsource.w3x";
-
-    /// <summary>
-    ///   File containing Warcraft 3 objects that will be added to the final result.
-    /// </summary>
-    private const string BASE_OBJECT_PATH = @"..\..\..\..\..\source.w3o";
+    private const string SourceCodeProjectFolderPath = @"..\..\..\..\AzerothWarsCSharp.Source";
+    private const string TestSourceCodeProjectFolderPath = @"..\..\..\..\AzerothWarsCSharp.TestSource";
+    private const string AssetsFolderPath = @"..\..\..\..\Assets\";
+    private const string BaseMapPath = @"..\..\..\..\..\maps\source.w3x";
+    private const string TestMapPath = @"..\..\..\..\..\maps\testsource.w3x";
 
     // Output
-    private const string OUTPUT_FOLDER_PATH = @"..\..\..\..\..\artifacts";
-    private const string OUTPUT_SCRIPT_NAME = @"war3map.lua";
-    private const string OUTPUT_MAP_NAME = @"target.w3x";
+    private const string OutputFolderPath = @"..\..\..\..\..\artifacts";
+    private const string OutputScriptName = @"war3map.lua";
+    private const string OutputMapName = @"target.w3x";
 
     // Warcraft III
-    private const string GRAPHICS_API = "Direct3D9";
+    private const string GraphicsApi = "Direct3D9";
 #if DEBUG
     private const bool DEBUG = true;
 #else
-		private const bool DEBUG = false;
+		private const bool Debug = false;
 #endif
 
     /// <summary>
@@ -65,19 +59,19 @@ namespace AzerothWarsCSharp.Launcher
       switch (Console.ReadKey().Key)
       {
         case ConsoleKey.D1:
-          ConstantGenerator.Run(BASE_MAP_PATH, SOURCE_CODE_PROJECT_FOLDER_PATH, new ConstantGeneratorOptions
+          ConstantGenerator.Run(BaseMapPath, SourceCodeProjectFolderPath, new ConstantGeneratorOptions
           {
             IncludeCode = true
           });
           break;
         case ConsoleKey.D2:
-          Build(BASE_MAP_PATH, SOURCE_CODE_PROJECT_FOLDER_PATH, false);
+          Build(BaseMapPath, SourceCodeProjectFolderPath, false);
           break;
         case ConsoleKey.D3:
-          Build(BASE_MAP_PATH, SOURCE_CODE_PROJECT_FOLDER_PATH, true);
+          Build(BaseMapPath, SourceCodeProjectFolderPath, true);
           break;
         case ConsoleKey.D4:
-          Build(TEST_MAP_PATH, TEST_SOURCE_CODE_PROJECT_FOLDER_PATH, true);
+          Build(TestMapPath, TestSourceCodeProjectFolderPath, true);
           break;
         default:
           Console.WriteLine($"{Environment.NewLine}Invalid input. Please choose again.");
@@ -92,8 +86,8 @@ namespace AzerothWarsCSharp.Launcher
     private static void Build(string baseMapPath, string projectFolderPath, bool launch)
     {
       // Ensure these folders exist
-      Directory.CreateDirectory(ASSETS_FOLDER_PATH);
-      Directory.CreateDirectory(OUTPUT_FOLDER_PATH);
+      Directory.CreateDirectory(AssetsFolderPath);
+      Directory.CreateDirectory(OutputFolderPath);
 
       // Load existing map data
       var map = Map.Open(baseMapPath);
@@ -102,14 +96,14 @@ namespace AzerothWarsCSharp.Launcher
       SetTestPlayerSlot(map, 0);
       var builder = new MapBuilder(map);
       builder.AddFiles(baseMapPath, "*", SearchOption.AllDirectories);
-      builder.AddFiles(ASSETS_FOLDER_PATH, "*", SearchOption.AllDirectories);
+      builder.AddFiles(AssetsFolderPath, "*", SearchOption.AllDirectories);
 
       ObjectEditor.SupplmentMapWithObjectData(map);
 
       // Set debug options if necessary, configure compiler
-      const string csc = DEBUG ? "-debug -define:DEBUG" : null;
+      const string csc = Debug ? "-debug -define:DEBUG" : null;
       var csproj = Directory.EnumerateFiles(projectFolderPath, "*.csproj", SearchOption.TopDirectoryOnly).Single();
-      var compiler = new Compiler(csproj, OUTPUT_FOLDER_PATH, string.Empty, null,
+      var compiler = new Compiler(csproj, OutputFolderPath, string.Empty, null,
         "War3Api.*;WCSharp.*;AzerothWarsCSharp.MacroTools.*", "", csc, false, null,
         string.Empty)
       {
@@ -117,7 +111,7 @@ namespace AzerothWarsCSharp.Launcher
         IsModule = false,
         IsInlineSimpleProperty = false,
         IsPreventDebugObject = true,
-        IsCommentsDisabled = !DEBUG
+        IsCommentsDisabled = !Debug
       };
 
       // Collect required paths and compile
@@ -133,7 +127,7 @@ namespace AzerothWarsCSharp.Launcher
         throw new Exception(compileResult.Diagnostics.First(x => x.Severity == DiagnosticSeverity.Error).GetMessage());
 
       // Update war3map.lua so you can inspect the generated Lua code easily
-      File.WriteAllText(Path.Combine(OUTPUT_FOLDER_PATH, OUTPUT_SCRIPT_NAME), map.Script);
+      File.WriteAllText(Path.Combine(OutputFolderPath, OutputScriptName), map.Script);
 
       // Build w3x file
       var archiveCreateOptions = new MpqArchiveCreateOptions
@@ -143,7 +137,7 @@ namespace AzerothWarsCSharp.Launcher
         ListFileCreateMode = MpqFileCreateMode.Overwrite
       };
 
-      builder.Build(Path.Combine(OUTPUT_FOLDER_PATH, OUTPUT_MAP_NAME), archiveCreateOptions);
+      builder.Build(Path.Combine(OutputFolderPath, OutputMapName), archiveCreateOptions);
 
       // Launch if that option was selected
       if (launch) LaunchGame();
@@ -180,11 +174,11 @@ namespace AzerothWarsCSharp.Launcher
       {
         var commandLineArgs = new StringBuilder();
         var isReforged = Version.Parse(FileVersionInfo.GetVersionInfo(wc3Exe).FileVersion) >= new Version(1, 32);
-        commandLineArgs.Append(isReforged ? " -launch" : $" -graphicsapi {GRAPHICS_API}");
+        commandLineArgs.Append(isReforged ? " -launch" : $" -graphicsapi {GraphicsApi}");
 
         commandLineArgs.Append(" -nowfpause");
 
-        var mapPath = Path.Combine(OUTPUT_FOLDER_PATH, OUTPUT_MAP_NAME);
+        var mapPath = Path.Combine(OutputFolderPath, OutputMapName);
         var absoluteMapPath = new FileInfo(mapPath).FullName;
         commandLineArgs.Append($" -loadfile \"{absoluteMapPath}\"");
 

--- a/src/AzerothWarsCSharp.Launcher/Program.cs
+++ b/src/AzerothWarsCSharp.Launcher/Program.cs
@@ -32,7 +32,7 @@ namespace AzerothWarsCSharp.Launcher
     // Warcraft III
     private const string GraphicsApi = "Direct3D9";
 #if DEBUG
-    private const bool DEBUG = true;
+    private const bool Debug = true;
 #else
 		private const bool Debug = false;
 #endif

--- a/src/AzerothWarsCSharp.Launcher/app.config
+++ b/src/AzerothWarsCSharp.Launcher/app.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-   <appSettings>
-     <add key="wc3exe" value="C:\Program Files (x86)\Warcraft III\_retail_\x86_64\Warcraft III.exe" />
-   </appSettings>
-</configuration>

--- a/src/AzerothWarsCSharp.Launcher/appsettings.json
+++ b/src/AzerothWarsCSharp.Launcher/appsettings.json
@@ -1,0 +1,6 @@
+{
+    "LaunchSettings": {
+        "TestingPlayerSlot": 0,
+        "Warcraft3ExecutablePath": "C:\\Program Files (x86)\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe"
+    }
+}


### PR DESCRIPTION
Lets developers choose which player slot they want to play as when running the launcher.
Also changes usage of app.config to appsettings.json.